### PR TITLE
feat: seperate connectionParams from headers options for web socket

### DIFF
--- a/src/kikstart-apollo-client.ts
+++ b/src/kikstart-apollo-client.ts
@@ -17,6 +17,7 @@ export interface KikstartGraphQLClientConfig extends KikstartGraphQLLinkConfig {
   wsOptions?: any;
   cache?: any;
   headers?: any;
+  connectionParams?: any;
   log?: any;
   // DEPRECATED to be removed in an upcoming major release
   uri?: string;

--- a/src/kikstart-graphql-client.ts
+++ b/src/kikstart-graphql-client.ts
@@ -39,9 +39,7 @@ export class GraphQLClient {
       config.wsUrl,
       {
         ...config.wsOptions,
-        connectionParams: {
-          headers: config.headers || {},
-        },
+        connectionParams: config.connectionParams,
         reconnect: true,
       },
       ws,


### PR DESCRIPTION
I needed to set connectionParams without "headers" filed.

So I added "connectionParams" configuration.